### PR TITLE
In importEventsFromIcsContent() den zu ladenden Kalenderzeitraum auf

### DIFF
--- a/includes/Import.php
+++ b/includes/Import.php
@@ -76,49 +76,7 @@ class Import
             ini_set('memory_limit', '512M');
         }
 
-        $startdate = 0;
-        $pastdays = 0;
         $limitdays = 365;
-
-        if ((!empty($startdate) && intval($startdate) > 20000000)) {
-            $rangeStart = date(
-                'Y/m/d',
-                gmmktime(
-                    0,
-                    0,
-                    0,
-                    substr($startdate, 4, 2),
-                    substr($startdate, 6, 2) - 1,
-                    substr($startdate, 0, 4)
-                )
-            );
-            $rangeEnd = date(
-                'Y/m/d',
-                gmmktime(
-                    0,
-                    0,
-                    0,
-                    substr($startdate, 4, 2),
-                    substr($startdate, 6, 2) + $limitdays + 7,
-                    substr($startdate, 0, 4)
-                )
-            );
-        } else {
-            if (!empty($pastdays)) {
-                // Rolling "past days" start (from beginning of current month)
-                $rangeStart = date('Y/m/d', gmmktime(0, 0, 0, date('n'), 0 - $pastdays, date('Y')));
-            } else {
-                // Middle of last month (to cover week view's "last week" option)
-                $rangeStart = date('Y/m/d', gmmktime(0, 0, 0, date('n'), -15, date('Y')));
-            }
-            // Extend by "limitdays" + one week past current date
-            $rangeEnd = date('Y/m/d', gmmktime(0, 0, 0, date('n'), date('j') + $limitdays + 7, date('Y')));
-        }
-
-        $dateTimeNow = new \DateTime();
-        $filterDaysAfter = $dateTimeNow->diff(new \DateTime($rangeEnd))->format('%a');
-        $filterDaysBefore = $dateTimeNow->diff(new \DateTime($rangeStart))->format('%a');
-
         $skipRecurrence = false;
         $tzid = get_option('timezone_string');
         $tz = Util::isValidTimezoneID($tzid) ? timezone_open($tzid) : wp_timezone();
@@ -131,8 +89,6 @@ class Import
                     'defaultTimeZone'             => $tz->getName(),
                     'defaultWeekStart'            => 'MO',
                     'disableCharacterReplacement' => true,
-                    'filterDaysAfter'             => $filterDaysAfter,
-                    'filterDaysBefore'            => $filterDaysBefore,
                     'replaceWindowsTimeZoneIds'   => true,
                     'skipRecurrence'              => $skipRecurrence
                 ]


### PR DESCRIPTION
die Defaults von ICal gesetzt.

Vorteil: man will zu einer deutschen Seite mit Kalender eine verknuepfte z.b. englische Seite erstellen, und beide sollen einen Kalender enthalten. Dann muss wegen der kranken Mechanik von Wordpress die englische "Website" eine eigene Datenbank fuer Kalender haben. Mit der vorigen Version hatte die dann einen Bruchteil der Kalendereintraege der deutschen Version, wenn die deutsche schon laenger lief, weil das importEventsFromIcsContent() nur die letzten paar importiert hat. So hat man zumindest auf ein Jahr zurueck das gleiche drinstehen.