### PR TITLE
Kalender auch als Archiv alter Veranstaltungen nutzbar machen, "start=.." "end=" fuer den Shortcode implementieren

### DIFF
--- a/includes/CPT/CalendarFeed.php
+++ b/includes/CPT/CalendarFeed.php
@@ -487,7 +487,7 @@ class CalendarFeed
     {
         $valuePastDays = get_post_meta($postId, CalendarFeed::FEED_PAST_DAYS, true);
         if ($valuePastDays == '') {
-            $valuePastDays = 365;
+            $valuePastDays = 36500;
         } else {
             $valuePastDays = intval($valuePastDays);
         }

--- a/includes/ICS/Events.php
+++ b/includes/ICS/Events.php
@@ -9,13 +9,13 @@ use RRZE\Calendar\CPT\{CalendarEvent, CalendarFeed};
 
 class Events
 {
-    private static $pastDays = 365;
+    private static $pastDays = 36500;
 
-    private static $limitDays = 365;
+    private static $limitDays = 36500;
 
     public static function updateFeedsItems()
     {
-        self::deleteUnlinkedEvents();
+        // self::deleteUnlinkedEvents();
 
         $feeds = self::getFeeds();
         foreach ($feeds as $post) {
@@ -41,7 +41,7 @@ class Events
         return get_posts($args);
     }
 
-    public static function updateItems(int $postId, bool $cache = true, int $pastDays = 365, int $limitDays = 365)
+    public static function updateItems(int $postId, bool $cache = true, int $pastDays = 36500, int $limitDays = 36500)
     {
         $events = Import::getEvents($postId, $cache, $pastDays, $limitDays);
 

--- a/includes/ICS/Import.php
+++ b/includes/ICS/Import.php
@@ -22,7 +22,7 @@ class Import
      * @param integer $limitDays
      * @return mixed
      */
-    public static function getEvents(int $feedID, bool $cache = true, int $pastDays = 365, int $limitDays = 365)
+    public static function getEvents(int $feedID, bool $cache = true, int $pastDays = 36500, int $limitDays = 36500)
     {
         $pastDays = abs($pastDays);
         $limitDays = abs($limitDays);

--- a/includes/ICS/Metabox.php
+++ b/includes/ICS/Metabox.php
@@ -45,7 +45,7 @@ class Metabox
         $value = (string) get_post_meta($post->ID, CalendarFeed::FEED_URL, true);
         $valuePastDays = get_post_meta($post->ID, CalendarFeed::FEED_PAST_DAYS, true);
         if ($valuePastDays == '') {
-            $valuePastDays = 365;
+            $valuePastDays = 36500;
         } else {
             $valuePastDays = intval($valuePastDays);
         }
@@ -68,8 +68,8 @@ class Metabox
         echo '<tr>',
             '<th><label for="' . CalendarFeed::FEED_PAST_DAYS . '">', __('Past Events', 'rrze-calendar'), '</label></th>';
         echo '<td>';
-        echo '<input name="' . CalendarFeed::FEED_PAST_DAYS . '" type="number" id="rrze-calendar-feed-past-days" aria-describedby="', _e('Past Events', 'rrze-calendar'), '" class="" value="', $valuePastDays, '" autocomplete="off" min="30" max="365"/>';
-        echo '<p class="description">', _e('For how many days in the past events are imported (max: 365, min:30)? Older events are deleted from the website.', 'rrze-calendar'), '</p>';
+        echo '<input name="' . CalendarFeed::FEED_PAST_DAYS . '" type="number" id="rrze-calendar-feed-past-days" aria-describedby="', _e('Past Events', 'rrze-calendar'), '" class="" value="', $valuePastDays, '" autocomplete="off" min="30" max="36500"/>';
+        echo '<p class="description">', _e('For how many days in the past events are imported (max: 36500, min:30)? Older events are deleted from the website.', 'rrze-calendar'), '</p>';
         echo '</td></tr>';
 
         echo '<tr>',
@@ -135,8 +135,8 @@ class Metabox
 
         if (array_key_exists(CalendarFeed::FEED_PAST_DAYS, $_POST)) {
             $feed_past_days = intval($_POST[CalendarFeed::FEED_PAST_DAYS]);
-            if ($feed_past_days > 365) {
-               $feed_past_days = 365;
+            if ($feed_past_days > 36500) {
+               $feed_past_days = 36500;
             } elseif ($feed_past_days < 30) {
                $feed_past_days = 30;
             }

--- a/includes/Shortcodes/Events.php
+++ b/includes/Shortcodes/Events.php
@@ -33,8 +33,8 @@ class Events
             'page_link' => '',    // ID of a target page, e.g. to display further events
             'page_link_label' => __('Show All Events', 'rrze-calendar'),
             'abonnement_link' => '',    // Display link to ICS Feed
-            'start' => '',       // Start date of appointment list. Format: "Y-m-d" or use a PHP relative date format
-            'end' => '',          // End date of appointment listing. Format: "Y-m-d" or use a PHP relative date format
+	    'start' => 'now' ,       // Start date of appointment list. Format: "Y-m-d" or use a PHP relative date format
+            'end' => '+10 years',          // End date of appointment listing. Format: "Y-m-d" or use a PHP relative date format
             'include' => '',
             'exclude' => '',
         ];
@@ -133,7 +133,9 @@ class Events
         $output = '<div class="rrze-calendar">';
 
         if (!empty($events)) {
-            $eventsArray = Utils::buildEventsArray($events, date('Y-m-d', time()), date('Y-m-d', strtotime('+1 year')));
+		$eventsArray = 
+			Utils::buildEventsArray($events, date('Y-m-d', strtotime($atts['start'])), 
+		   	                                 date('Y-m-d', strtotime($atts['end'])));
             if ($eventsArray) {
                 ksort($eventsArray);
             }
@@ -166,7 +168,9 @@ class Events
             $i = 0;
             $output .= '<ul class="' . $ulClass . '">';
             foreach ($eventsArray as $tsCount => $events) {
-                if (date('Ymd',$tsCount) < date('Ymd', time())) continue;
+              // if (date('Ymd',$tsCount) < date('Ymd', time())) continue;
+              if (date('Ymd',$tsCount) < date('Ymd', strtotime($atts['start']))) continue;
+              if (date('Ymd',$tsCount) > date('Ymd', strtotime($atts['end']))) continue;
 
                 foreach ($events as $event) {
                     $tsEnd = $event['end'];
@@ -265,7 +269,7 @@ class Events
                             . '<div class="day">' . date('d', $tsCount) . '</div>'
                             . '<div class="month">' . date_i18n('M', $tsCount) . '</div>'
                             . '</div>'
-                            //. '<div class="year">' . date('Y', $tsStart) .'</div>'
+                            . '<div class="year">' . date('Y', $tsStart) .'</div>'
                             . '</div>'
                             . '<div class="event-info">'
                             . ($dateOut != '' ? '<div class="event-time">' . $dateOut . '</div>' : '')


### PR DESCRIPTION
Hi,
zwei Changes:
 1. wir nutzen den Kalender auch fuer die Auflistung von frueheren Veranstaltungen,
     u.a. weil Profs auf der Webseite zeigen wollen, wer schon alles hier vorgetragen
     hat. Dazu musste ich die Rueckhaltezeit von einem Jahr auf was groesseres
     verlaengern
 2. Das [termine start="1234-05-67" end="4321-01-23"] war nicht implementiert.
 RvdF ist informiert..     